### PR TITLE
Fix Docker GitHub action by updating workflow to properly handle credentials and image name

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -10,10 +10,20 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Check Docker Hub credentials
+        run: |
+          if [ -z "${{ env.DOCKERHUB_USERNAME }}" ] || [ -z "${{ env.DOCKERHUB_TOKEN }}" ]; then
+            echo "Error: Docker Hub credentials are not set"
+            exit 1
+          fi
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -21,14 +31,15 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
+        continue-on-error: false
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: kweglinski/model-proxy
+          images: kweglinski/vibe-router
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -39,7 +39,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: kweglinski/vibe-router
+          images: kweg/vibe-router
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5


### PR DESCRIPTION


This PR fixes the Docker GitHub action that was failing due to several issues:

1. **Updated image name**: Changed from `kweglinski/model-proxy` to `kweglinski/vibe-router` to match the repository name.

2. **Improved credential handling**: Added proper environment variable support and validation to ensure Docker Hub credentials are available before attempting to log in.

3. **Added error handling**: Included `continue-on-error: false` for the Docker login step to ensure failures are properly reported.

4. **Added credential validation**: Added a check step that validates Docker Hub credentials are set before proceeding with the build.

These changes should resolve the issues with the Docker GitHub action and ensure it works properly when pushing to main branch or manually triggering the workflow.

