### PR TITLE
Add /v1/models endpoint to list available models with OpenAI API compatibility

### DIFF
--- a/__tests__/integration.test.js
+++ b/__tests__/integration.test.js
@@ -38,7 +38,39 @@ describe('Integration Tests', () => {
     app.use(bodyParser.json());
     app.use(cors({ origin: '*' }));
 
-    // Setup the route
+    // Setup the routes
+    app.get('/v1/models', (req, res) => {
+      try {
+        const modelMapping = config.modelMapping || {};
+        const modelsConfig = config.models || {};
+
+        // Format the response according to OpenAI API spec
+        const models = Object.keys(modelMapping).map(systemName => {
+          // Get the actual model name and API info
+          const actualModel = modelMapping[systemName];
+          const apiInfo = modelsConfig[systemName]?.api || null;
+
+          return {
+            id: systemName,
+            object: "model",
+            owned_by: "organization-name", // Default value as per OpenAI spec
+            additional: {
+              actual_model: actualModel,
+              api_name: apiInfo
+            }
+          };
+        });
+
+        res.json({
+          object: "list",
+          data: models
+        });
+      } catch (error) {
+        console.error('Error listing models:', error.message);
+        res.status(500).json({ error: 'Internal server error' });
+      }
+    });
+
     app.post('/v1/completions', async (req, res) => {
       try {
         // Replace model name in the request
@@ -87,6 +119,39 @@ describe('Integration Tests', () => {
     } else {
       // In local environment, we can check if the server is available
       expect(response.status).toBeGreaterThanOrEqual(200);
+    }
+  });
+
+  test('should list available models with correct format', async () => {
+    const response = await request(server)
+      .get('/v1/models')
+      .set('Content-Type', 'application/json');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('object', 'list');
+    expect(response.body).toHaveProperty('data');
+
+    // Check that each model has the expected structure
+    const models = response.body.data;
+    expect(models).toHaveLength(3); // Should match the number of models in config.json
+
+    models.forEach(model => {
+      expect(model).toHaveProperty('id');
+      expect(model).toHaveProperty('object', 'model');
+      expect(model).toHaveProperty('owned_by', 'organization-name');
+      expect(model).toHaveProperty('additional');
+      expect(model.additional).toHaveProperty('actual_model');
+      expect(model.additional).toHaveProperty('api_name');
+
+      // Check that the system name matches one of our configured models
+      expect(['thinker', 'coder', 'quick']).toContain(model.id);
+    });
+
+    // Check specific model details
+    const thinkerModel = models.find(m => m.id === 'thinker');
+    if (thinkerModel) {
+      expect(thinkerModel.additional.actual_model).toBe('devstral-small-2507-mlx');
+      expect(thinkerModel.additional.api_name).toBe('lmstudio');
     }
   });
 });

--- a/working-proxy.js
+++ b/working-proxy.js
@@ -59,6 +59,39 @@ function replaceModelName(request) {
   return request;
 }
 
+// Endpoint to list available models (OpenAI API compatible)
+app.get('/v1/models', (req, res) => {
+  try {
+    const modelMapping = config.modelMapping || {};
+    const modelsConfig = config.models || {};
+
+    // Format the response according to OpenAI API spec
+    const models = Object.keys(modelMapping).map(systemName => {
+      // Get the actual model name and API info
+      const actualModel = modelMapping[systemName];
+      const apiInfo = modelsConfig[systemName]?.api || null;
+
+      return {
+        id: systemName,
+        object: "model",
+        owned_by: "organization-name", // Default value as per OpenAI spec
+        additional: {
+          actual_model: actualModel,
+          api_name: apiInfo
+        }
+      };
+    });
+
+    res.json({
+      object: "list",
+      data: models
+    });
+  } catch (error) {
+    console.error('Error listing models:', error.message);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
 // Proxy endpoint for OpenAI-compatible API
 app.post('/v1/completions', async (req, res) => {
   try {


### PR DESCRIPTION
This PR adds a new `/v1/models` endpoint that:

1. Matches the OpenAI API spec for listing models
2. Lists models with system names (friendly names) as the model ID
3. Includes additional information under the `additional` key:
   - `actual_model`: The actual model name used underneath
   - `api_name`: The API name (if provided)

The endpoint returns a response in the following format:
```json
{
  "object": "list",
  "data": [
    {
      "id": "thinker",
      "object": "model",
      "owned_by": "organization-name",
      "additional": {
        "actual_model": "devstral-small-2507-mlx",
        "api_name": "lmstudio"
      }
    },
    // ... other models
  ]
}
```

Changes made:
- Added new `/v1/models` endpoint in `working-proxy.js`
- Updated integration tests to verify the new endpoint works correctly
- All existing functionality remains unchanged

This implementation provides better visibility into available models while maintaining compatibility with the OpenAI API specification.